### PR TITLE
Demonstrate support for exclusions in BOM import

### DIFF
--- a/excludes-in-bom/gradle/wrapper/gradle-wrapper.properties
+++ b/excludes-in-bom/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e66e69dce8173dd2004b39ba93586a184628bc6c28461bc771d6835f7f9b0d28
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionSha256Sum=2b05b1cab02a836cffa7e014288053960460186a4d15c95050f49ecaee024902
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.11-20180821151948+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform-support/gradle/wrapper/gradle-wrapper.properties
+++ b/platform-support/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f68220df44d943418a49aecccf0d5b8547f52201926bc8f13c2c3e5b81eb763a
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-rc-1-bin.zip
+distributionSha256Sum=2b05b1cab02a836cffa7e014288053960460186a4d15c95050f49ecaee024902
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.11-20180821151948+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform-support/repo/nebulatest/platform/1.0.0/platform-1.0.0.pom
+++ b/platform-support/repo/nebulatest/platform/1.0.0/platform-1.0.0.pom
@@ -9,6 +9,24 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.0.6.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>5.0.6.RELEASE</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+            </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>com.squareup.retrofit2</groupId>
         <artifactId>retrofit</artifactId>
         <version>2.4.0</version>
@@ -22,12 +40,4 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-framework-bom</artifactId>
-      <version>5.0.6.RELEASE</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
 </project>


### PR DESCRIPTION
This change demonstrates how support for <exclusions> defined in
an imported BOM could be used to allow a BOM to:
1. Take opinions from upstream BOM (<scope>import</scope>)
2. Override opinions in upstream BOM (<exclusions/> + replacement <dependency/>)
3. Exclude opinions in upstream BOM (<exclusions/>

Note that the Gradle version referenced by the wrapper was published
from the `dd/dm/bom-excludes` branch. These changes have not yet
been merged into `master`. There are known issues with this codebase
and it should be used for demonstration purposes only.